### PR TITLE
Remove as sendable fn

### DIFF
--- a/lazuli_core/src/client/connector.rs
+++ b/lazuli_core/src/client/connector.rs
@@ -8,7 +8,7 @@ use std::{
 
 use log::trace;
 
-use crate::{stream::Stream, ArcMutex, PacketHeader, Result, Sendable, UnknownType};
+use crate::{sendable, stream::Stream, ArcMutex, PacketHeader, Result, Sendable, UnknownType};
 
 /// A single byte type that is used to store the raw data.
 #[repr(transparent)]
@@ -34,7 +34,7 @@ impl StreamConnector {
             vec_ptr: unsafe { mem::transmute(stream.get_ptr()) },
             size: mem::size_of::<T>(),
             grew: stream.get_grow_by(),
-            conversion_fn: T::as_conversion_fn(),
+            conversion_fn: sendable::as_conversion_fn::<T>(),
             type_name: std::any::type_name::<T>(),
         }
     }

--- a/lazuli_core/src/sendable.rs
+++ b/lazuli_core/src/sendable.rs
@@ -43,23 +43,23 @@ pub trait Sendable: Sized + std::fmt::Debug {
 
     /// Converts an incoming stream of bytes to the type.
     fn recv(data: &mut dyn Read) -> Result<Self>;
+}
 
-    /// Converts the type to a function that can be used to convert incoming data to the type.
-    /// Returns a Vec<u8> that is the type's representation in memory.
-    /// This is used as a hacky way to convert the type if the type cant be known at runtime.
-    fn as_conversion_fn() -> fn(&mut dyn Read) -> Result<Box<[u8]>> {
-        |data| {
-            let conversion = Box::new(Self::recv(data)?);
-            trace!("Converted to bytes: {:?}", conversion);
-            let as_slice_bytes = unsafe {
-                // We use a slice to get the bytes of the type. This is safe because we are using the size of the type to get the slice.
-                slice::from_raw_parts(
-                    Box::leak(conversion) as *mut Self as *mut u8,
-                    mem::size_of::<Self>(),
-                )
-            };
-            Ok(as_slice_bytes.into())
-        }
+/// Converts the type to a function that can be used to convert incoming data to the type.
+/// Returns a Vec<u8> that is the type's representation in memory.
+/// This is used as a hacky way to convert the type if the type cant be known at runtime.
+pub(crate) fn as_conversion_fn<T: Sendable>() -> fn(&mut dyn Read) -> Result<Box<[u8]>> {
+    |data| {
+        let conversion = Box::new(T::recv(data)?);
+        trace!("Converted to bytes: {:?}", conversion);
+        let as_slice_bytes = unsafe {
+            // We use a slice to get the bytes of the type. This is safe because we are using the size of the type to get the slice.
+            slice::from_raw_parts(
+                Box::leak(conversion) as *mut T as *mut u8,
+                mem::size_of::<T>(),
+            )
+        };
+        Ok(as_slice_bytes.into())
     }
 }
 

--- a/lazuli_core/src/sendable.rs
+++ b/lazuli_core/src/sendable.rs
@@ -46,8 +46,9 @@ pub trait Sendable: Sized + std::fmt::Debug {
 }
 
 /// Converts the type to a function that can be used to convert incoming data to the type.
-/// Returns a Vec<u8> that is the type's representation in memory.
-/// This is used as a hacky way to convert the type if the type cant be known at runtime.
+/// This function hides the type of the data, allowing for the conversion function to be used in a generic context.
+///
+/// This function is used internally by `StreamConnector`.
 pub(crate) fn as_conversion_fn<T: Sendable>() -> fn(&mut dyn Read) -> Result<Box<[u8]>> {
     |data| {
         let conversion = Box::new(T::recv(data)?);


### PR DESCRIPTION
Removes `as_sendable_fn` from `Sendable` and moves it to the root of the module. This PR also changes the access modifier from the implicit `pub` to `pub(crate)`, and improves the documentation for the function.

Closes #1 