### PR TITLE
Have tests use socket 0 for port allocation

### DIFF
--- a/lazuli_core/src/client/mod.rs
+++ b/lazuli_core/src/client/mod.rs
@@ -29,38 +29,16 @@ mod test_utils {
     /// (client, server)
     pub(super) fn make_client_server_pair() -> (Client, Client) {
         use std::net::TcpListener;
-        let server = TcpListener::bind((Ipv4Addr::LOCALHOST, 0));
-
-        if let Err(e) = server {
-            // If the port is in use, try again.
-            if e.kind() == std::io::ErrorKind::AddrInUse {
-                return make_client_server_pair();
-            } else {
-                panic!("Failed to bind server: {}", e);
-            }
-        }
-
-        let server = server.unwrap();
+        let server = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("Failed to create server!");
 
         let client = Client::connect(server.local_addr().unwrap()).unwrap();
         let server = server.accept().unwrap().0;
 
         (client, Client::from_stream(server))
     }
-
+    /// Creates a Server. Expects the OS to assign a port.
     pub(super) fn make_server() -> Server {
-        let server = Server::new((Ipv4Addr::LOCALHOST, 0));
-
-        if let Err(e) = server {
-            // If the port is in use, try again.
-            if e.kind() == std::io::ErrorKind::AddrInUse {
-                return make_server();
-            } else {
-                panic!("Failed to bind server: {}", e);
-            }
-        }
-
-        server.unwrap()
+        Server::new((Ipv4Addr::LOCALHOST, 0)).expect("Failed to create server!")
     }
 
     /// Tests sending and receiving data. Convenience function for testing.

--- a/lazuli_core/src/client/server.rs
+++ b/lazuli_core/src/client/server.rs
@@ -74,7 +74,9 @@ impl Server {
 
 #[cfg(test)]
 mod test {
-    use crate::client::test_utils::{get_socket_addr, make_server, test_send_recv};
+    use std::net::Ipv4Addr;
+
+    use crate::client::test_utils::{make_server, test_send_recv};
 
     use super::*;
 
@@ -114,7 +116,7 @@ mod test {
     }
     #[test]
     fn test_nonblocking_server() -> Result<()> {
-        let mut server = Server::new_nonblocking(get_socket_addr())?;
+        let mut server = Server::new_nonblocking((Ipv4Addr::LOCALHOST, 0))?;
         assert!(server.accept().is_err());
         if let Err(e) = server.accept() {
             assert_eq!(e.kind(), std::io::ErrorKind::WouldBlock);


### PR DESCRIPTION
Remove the code to dynamically allocate ports for tests, and use port 0 which allows for the OS to allocate ports.

Closes #10 